### PR TITLE
NOTE-1: Add booklist updating command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Project-specific
+config.toml

--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,7 @@ dev: ensure-poetry clean
 
 install: ensure-poetry clean
 	poetry install --no-dev
+
+gen-config: ensure-poetry install
+	rm -f config.toml.example
+	poetry run notion_scripts --config config.toml.example

--- a/README.md
+++ b/README.md
@@ -1,2 +1,61 @@
-# notion_scripts
-Various scripts I use to interact with notion
+# Notion Scripts
+Various tools and scripts I use to interact with Notion.
+
+- [Notion Scripts](#notion-scripts)
+- [Config](#config)
+- [Usage](#usage)
+- [Help](#help)
+- [Commands](#commands)
+  - [`booklist`](#booklist)
+
+# Config
+The config is in [TOML](https://toml.io/en/) and is supplied with the `-c/--config` option. If the file doesn't exist at the given path, the CLI will auto-generate one with default values and stop execution (it won't continue with your command) - this is how the example config file is generated.
+
+For information on particular config attributes, check out the [ConfigSchema comments](notion_scripts/config.py).
+
+# Usage
+The project uses [poetry](https://python-poetry.org/) for dependency management and running. To run the CLI, you can type:
+
+```
+python run notion_scripts --config <path_to_config_file> <command_name>
+```
+
+# Help
+For help, you can pass the `--help` flag at any time. 
+
+For example, for help for the `booklist` command, you should type:
+
+```
+python run notion_scripts --config config.toml.example booklist --help
+```
+
+# Commands
+
+## `booklist`
+
+Updates a database with information fetched from the goodreads API. It maps the notion database column names to results from the goodreads API based on book title, then updates the database with those values.
+
+For example, the included mapping config is:
+
+```
+pages = "num_pages"
+publication_year = "publication_year"
+publication_month = "publication_month"
+publication_day = "publication_day"
+rating = "average_rating"
+name = "title"
+```
+
+| Column Name  | Goodreads API Field  |
+|---|---|
+| Pages | "num_pages" |
+| publication_year | "publication_year" |
+| publication_month | "publication_month" |
+| publication_day | "publication_day" |
+| Rating | "average_rating" |
+| name | "title" |
+
+**Limitations:**
+
+* Can only insert data from the first-level of the Goodreads API response
+* Can't handle select/multi-select elements as I haven't discovered a way to upsert options

--- a/config.toml.example
+++ b/config.toml.example
@@ -1,4 +1,12 @@
 token = "<token_v2>"
 
 [booklist_info]
+goodreads_api_token = "Get a token from https://www.goodreads.com/api/keys"
 page = "https://www.notion.so/<some_org_id>/<a_page_id>"
+
+[booklist_info.columns]
+Pages = "num_pages"
+publication_year = "publication_year"
+publication_month = "publication_month"
+publication_day = "publication_day"
+Rating = "average_rating"

--- a/config.toml.example
+++ b/config.toml.example
@@ -1,12 +1,13 @@
 token = "<token_v2>"
 
 [booklist_info]
-goodreads_api_token = "Get a token from https://www.goodreads.com/api/keys"
 page = "https://www.notion.so/<some_org_id>/<a_page_id>"
+goodreads_api_token = "Get a token from https://www.goodreads.com/api/keys"
 
 [booklist_info.columns]
-Pages = "num_pages"
+pages = "num_pages"
 publication_year = "publication_year"
 publication_month = "publication_month"
 publication_day = "publication_day"
-Rating = "average_rating"
+rating = "average_rating"
+name = "title"

--- a/notion_scripts/__init__.py
+++ b/notion_scripts/__init__.py
@@ -2,7 +2,7 @@ from notion_scripts.cli import scripts
 
 
 def main():
-    scripts(obj={}, prog_name='scripts')    # pylint: disable=unexpected-keyword-arg,no-value-for-parameter
+    scripts(obj={}, prog_name='notion_scripts')    # pylint: disable=unexpected-keyword-arg,no-value-for-parameter
 
 
 if __name__ == '__main__':

--- a/notion_scripts/booklist_info/__init__.py
+++ b/notion_scripts/booklist_info/__init__.py
@@ -13,7 +13,7 @@ class BooklistInfo():
 
     def _get_db_data(self):
         cv = self.client.get_collection_view(self.config.get('page'))
-        return cv.collection.get_rows(search="Penguin")
+        return cv.collection.get_rows()
 
     def _process_table_data(self, data):
         for row in data:

--- a/notion_scripts/booklist_info/__init__.py
+++ b/notion_scripts/booklist_info/__init__.py
@@ -1,0 +1,4 @@
+
+
+class BooklistInfo():
+    pass

--- a/notion_scripts/booklist_info/__init__.py
+++ b/notion_scripts/booklist_info/__init__.py
@@ -1,4 +1,36 @@
+import goodreads_api_client as gr
 
 
 class BooklistInfo():
-    pass
+
+    def __init__(self, context):
+        self.client = context.obj['client']
+        self.config = context.obj['config'].get('booklist_info')
+        self.gr_client = gr.Client(developer_key=self.config.get('goodreads_api_token'))
+
+        table_data = self._get_db_data()
+        self._process_table_data(table_data)
+
+    def _get_db_data(self):
+        cv = self.client.get_collection_view(self.config.get('page'))
+        return cv.collection.get_rows(search="Penguin")
+
+    def _process_table_data(self, data):
+        for row in data:
+            if row.do_not_process:
+                print(f"Not processing {row.title}")
+                continue
+            print(f"Now processing {row.title}")
+
+            book = self.gr_client.Book.title(row.title)  # pylint: disable=no-member
+            print(f"Got book info for goodreads book {book.get('title')}")
+            if book:
+                for column, api_field in self.config.get('columns').items():
+                    coltype = type(getattr(row, column)) if getattr(row, column) is not None else str
+                    raw_value = book.get(api_field)
+                    if raw_value:
+                        # Cast the value to the appropriate type
+                        value = coltype(raw_value)
+                        setattr(row, column, value)
+
+            row.do_not_process = True

--- a/notion_scripts/booklist_info/__init__.py
+++ b/notion_scripts/booklist_info/__init__.py
@@ -20,7 +20,7 @@ class BooklistInfo():
             if row.do_not_process:
                 print(f"Not processing {row.title}")
                 continue
-            print(f"Now processing {row.title}")
+            print(f"Processing {row.title}")
 
             book = self.gr_client.Book.title(row.title)  # pylint: disable=no-member
             print(f"Got book info for goodreads book {book.get('title')}")

--- a/notion_scripts/booklist_info/__init__.py
+++ b/notion_scripts/booklist_info/__init__.py
@@ -3,17 +3,21 @@ import goodreads_api_client as gr
 
 class BooklistInfo():
 
-    def __init__(self, context):
+    def __init__(self, context, page=None):
         self.client = context.obj['client']
         self.config = context.obj['config'].get('booklist_info')
         self.logger = context.obj['logger']
         self.gr_client = gr.Client(developer_key=self.config.get('goodreads_api_token'))
 
+        self.page = self.config.get('page')
+        if page:
+            self.page = page
+
         table_data = self._get_db_data()
         self._process_table_data(table_data)
 
     def _get_db_data(self):
-        cv = self.client.get_collection_view(self.config.get('page'))
+        cv = self.client.get_collection_view(self.page)
         return cv.collection.get_rows()
 
     def _process_table_data(self, data):
@@ -27,6 +31,9 @@ class BooklistInfo():
             self.logger.info(f"Got book info for goodreads book {book.get('title')}")
             if book:
                 for column, api_field in self.config.get('columns').items():
+                    # The notion API expects lowercase column names
+                    column = column.lower()
+
                     coltype = type(getattr(row, column)) if getattr(row, column) is not None else str
                     raw_value = book.get(api_field)
                     if raw_value:

--- a/notion_scripts/cli.py
+++ b/notion_scripts/cli.py
@@ -1,8 +1,10 @@
 import click
+import logging
 from notion.client import NotionClient
 
 
 from notion_scripts.config import Config
+from notion_scripts.logging import setup_logger
 from notion_scripts.booklist_info import BooklistInfo
 
 
@@ -12,8 +14,11 @@ from notion_scripts.booklist_info import BooklistInfo
 def scripts(ctx, config):
     """A CLI wrapper for the API of Public scripts."""
     ctx.ensure_object(dict)
+    ctx.obj['logger'] = setup_logger()
+    ctx.obj['logger'].setLevel(logging.DEBUG)
+
     ctx.obj['config'] = Config.load_config(config)
-    click.echo("Parsed config: " + repr(ctx.obj['config']))
+    ctx.obj['logger'].info("Parsed config: " + repr(ctx.obj['config']))
 
     ctx.obj['client'] = NotionClient(token_v2=ctx.obj['config'].get('token'))
 

--- a/notion_scripts/cli.py
+++ b/notion_scripts/cli.py
@@ -8,11 +8,13 @@ from notion_scripts.logging import setup_logger
 from notion_scripts.booklist_info import BooklistInfo
 
 
-@click.group()
-@click.option('-c', '--config', help='Full path to TOML config file', type=click.Path())
+@click.group(invoke_without_command=True)
+@click.option('-c', '--config', help='Full path to TOML config file (If one doesn\'t exist at that path, it will be generated for you and no commands will be run)', type=click.Path())
 @click.pass_context
 def scripts(ctx, config):
-    """A CLI wrapper for the API of Public scripts."""
+    """
+    A CLI wrapper for some helpful scripts I use on my personal Notion.
+    """
     ctx.ensure_object(dict)
     ctx.obj['logger'] = setup_logger()
     ctx.obj['logger'].setLevel(logging.DEBUG)
@@ -26,4 +28,9 @@ def scripts(ctx, config):
 @scripts.command()
 @click.pass_context
 def booklist(ctx):
+    """
+    Updates the given page/database with information from the goodreads API by
+    matching books based on title. You can configure the mapping of column names
+    to API results in the config.
+    """
     BooklistInfo(ctx)

--- a/notion_scripts/cli.py
+++ b/notion_scripts/cli.py
@@ -27,10 +27,11 @@ def scripts(ctx, config):
 
 @scripts.command()
 @click.pass_context
-def booklist(ctx):
+@click.option('-p', '--page', help='Notion URL to page/database to be updated', type=str, default=None)
+def booklist(ctx, page):
     """
     Updates the given page/database with information from the goodreads API by
     matching books based on title. You can configure the mapping of column names
     to API results in the config.
     """
-    BooklistInfo(ctx)
+    BooklistInfo(ctx, page)

--- a/notion_scripts/cli.py
+++ b/notion_scripts/cli.py
@@ -18,14 +18,9 @@ def scripts(ctx, config):
     ctx.obj['logger'].setLevel(logging.DEBUG)
 
     ctx.obj['config'] = Config.load_config(config)
-    ctx.obj['logger'].info("Parsed config: " + repr(ctx.obj['config']))
+    ctx.obj['logger'].debug("Parsed config: " + repr(ctx.obj['config']))
 
     ctx.obj['client'] = NotionClient(token_v2=ctx.obj['config'].get('token'))
-
-
-@scripts.command()
-def test():
-    pass
 
 
 @scripts.command()

--- a/notion_scripts/cli.py
+++ b/notion_scripts/cli.py
@@ -1,5 +1,9 @@
 import click
+from notion.client import NotionClient
+
+
 from notion_scripts.config import Config
+from notion_scripts.booklist_info import BooklistInfo
 
 
 @click.group()
@@ -11,7 +15,15 @@ def scripts(ctx, config):
     ctx.obj['config'] = Config.load_config(config)
     click.echo("Parsed config: " + repr(ctx.obj['config']))
 
+    ctx.obj['client'] = NotionClient(token_v2=ctx.obj['config'].get('token'))
+
 
 @scripts.command()
 def test():
     pass
+
+
+@scripts.command()
+@click.pass_context
+def booklist_info(ctx):
+    BooklistInfo(ctx)

--- a/notion_scripts/cli.py
+++ b/notion_scripts/cli.py
@@ -7,7 +7,7 @@ from notion_scripts.booklist_info import BooklistInfo
 
 
 @click.group()
-@click.option('-c', '--config', help='Full path to TOML config file')
+@click.option('-c', '--config', help='Full path to TOML config file', type=click.Path())
 @click.pass_context
 def scripts(ctx, config):
     """A CLI wrapper for the API of Public scripts."""
@@ -25,5 +25,5 @@ def test():
 
 @scripts.command()
 @click.pass_context
-def booklist_info(ctx):
+def booklist(ctx):
     BooklistInfo(ctx)

--- a/notion_scripts/config.py
+++ b/notion_scripts/config.py
@@ -13,8 +13,13 @@ class Config(Schema):
         unknown = INCLUDE
 
     class BooklistInfoSchema(Schema):
+        # The notion database we want to update, this can be overridden with the --page option
         page = fields.Str(default="https://www.notion.so/<some_org_id>/<a_page_id>")
+
+        # API Token for goodreads
         goodreads_api_token = fields.Str(default="Get a token from https://www.goodreads.com/api/keys")
+
+        # A mapping of notion column names to first-level fields in goodreads API results
         columns = fields.Dict(
             keys=fields.Str(), values=fields.Str(),
             default={
@@ -27,7 +32,10 @@ class Config(Schema):
             }
         )
 
+    # This is the logged-in user token for Notion - instructions here: https://github.com/jamalex/notion-py#usage
     token = fields.Str(default="<token_v2>")
+
+    # Config section for the booklist command
     booklist_info = fields.Nested(BooklistInfoSchema, default=BooklistInfoSchema())
 
     @staticmethod

--- a/notion_scripts/config.py
+++ b/notion_scripts/config.py
@@ -18,11 +18,12 @@ class Config(Schema):
         columns = fields.Dict(
             keys=fields.Str(), values=fields.Str(),
             default={
-                "Pages": "num_pages",
+                "pages": "num_pages",
                 "publication_year": "publication_year",
                 "publication_month": "publication_month",
                 "publication_day": "publication_day",
-                "Rating": "average_rating",
+                "rating": "average_rating",
+                "name": "title",
             }
         )
 

--- a/notion_scripts/config.py
+++ b/notion_scripts/config.py
@@ -12,11 +12,22 @@ class Config(Schema):
         # Include unknown fields in the deserialized output
         unknown = INCLUDE
 
-    class BooklistInfo(Schema):
+    class BooklistInfoSchema(Schema):
         page = fields.Str(default="https://www.notion.so/<some_org_id>/<a_page_id>")
+        goodreads_api_token = fields.Str(default="Get a token from https://www.goodreads.com/api/keys")
+        columns = fields.Dict(
+            keys=fields.Str(), values=fields.Str(),
+            default={
+                "Pages": "num_pages",
+                "publication_year": "publication_year",
+                "publication_month": "publication_month",
+                "publication_day": "publication_day",
+                "Rating": "average_rating",
+            }
+        )
 
     token = fields.Str(default="<token_v2>")
-    booklist_info = fields.Nested(BooklistInfo, default=BooklistInfo())
+    booklist_info = fields.Nested(BooklistInfoSchema, default=BooklistInfoSchema())
 
     @staticmethod
     def load_config(config_location):

--- a/notion_scripts/logging.py
+++ b/notion_scripts/logging.py
@@ -1,0 +1,11 @@
+import colorlog
+
+
+def setup_logger():
+    handler = colorlog.StreamHandler()
+    handler.setFormatter(colorlog.ColoredFormatter(
+        '%(log_color)s%(asctime)s %(levelname)-8s %(message)s', datefmt='%Y-%m-%d %H:%M'))
+
+    logger = colorlog.getLogger(__name__)
+    logger.addHandler(handler)
+    return logger

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,107 +1,112 @@
 [[package]]
-category = "dev"
-description = "An abstract syntax tree for Python with inference support."
 name = "astroid"
+version = "2.4.2"
+description = "An abstract syntax tree for Python with inference support."
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "2.4.2"
 
 [package.dependencies]
 lazy-object-proxy = ">=1.4.0,<1.5.0"
 six = ">=1.12,<2.0"
+typed-ast = {version = ">=1.4.0,<1.5", markers = "implementation_name == \"cpython\" and python_version < \"3.8\""}
 wrapt = ">=1.11,<2.0"
 
-[package.dependencies.typed-ast]
-python = "<3.8"
-version = ">=1.4.0,<1.5"
-
 [[package]]
-category = "main"
-description = "Screen-scraping library"
 name = "beautifulsoup4"
+version = "4.9.3"
+description = "Screen-scraping library"
+category = "main"
 optional = false
 python-versions = "*"
-version = "4.9.3"
 
 [package.dependencies]
-[package.dependencies.soupsieve]
-python = ">=3.0"
-version = ">1.2"
+soupsieve = {version = ">1.2", markers = "python_version >= \"3.0\""}
 
 [package.extras]
 html5lib = ["html5lib"]
 lxml = ["lxml"]
 
 [[package]]
-category = "main"
-description = "Dummy package for Beautiful Soup"
 name = "bs4"
+version = "0.0.1"
+description = "Dummy package for Beautiful Soup"
+category = "main"
 optional = false
 python-versions = "*"
-version = "0.0.1"
 
 [package.dependencies]
 beautifulsoup4 = "*"
 
 [[package]]
-category = "main"
-description = "A decorator for caching properties in classes."
 name = "cached-property"
-optional = false
-python-versions = "*"
 version = "1.5.2"
+description = "A decorator for caching properties in classes."
+category = "main"
+optional = false
+python-versions = "*"
 
 [[package]]
-category = "main"
-description = "Python package for providing Mozilla's CA Bundle."
 name = "certifi"
-optional = false
-python-versions = "*"
 version = "2020.11.8"
+description = "Python package for providing Mozilla's CA Bundle."
+category = "main"
+optional = false
+python-versions = "*"
 
 [[package]]
-category = "main"
-description = "Universal encoding detector for Python 2 and 3"
 name = "chardet"
-optional = false
-python-versions = "*"
 version = "3.0.4"
-
-[[package]]
+description = "Universal encoding detector for Python 2 and 3"
 category = "main"
-description = "Composable command line interface toolkit"
-name = "click"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "7.1.2"
-
-[[package]]
-category = "dev"
-description = "Cross-platform colored terminal text."
-marker = "sys_platform == \"win32\""
-name = "colorama"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.4.4"
-
-[[package]]
-category = "main"
-description = "Python parser for the CommonMark Markdown spec"
-name = "commonmark"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "click"
+version = "7.1.2"
+description = "Composable command line interface toolkit"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "colorama"
+version = "0.4.4"
+description = "Cross-platform colored terminal text."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "colorlog"
+version = "4.6.2"
+description = "Log formatting with colors!"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+
+[[package]]
+name = "commonmark"
 version = "0.9.1"
+description = "Python parser for the CommonMark Markdown spec"
+category = "main"
+optional = false
+python-versions = "*"
 
 [package.extras]
-test = ["flake8 (3.7.8)", "hypothesis (3.55.3)"]
+test = ["flake8 (==3.7.8)", "hypothesis (==3.55.3)"]
 
 [[package]]
-category = "main"
-description = "Dictdiffer is a library that helps you to diff and patch dictionaries."
 name = "dictdiffer"
+version = "0.8.1"
+description = "Dictdiffer is a library that helps you to diff and patch dictionaries."
+category = "main"
 optional = false
 python-versions = "*"
-version = "0.8.1"
 
 [package.extras]
 all = ["Sphinx (>=1.4.4)", "sphinx-rtd-theme (>=0.1.9)", "check-manifest (>=0.25)", "coverage (>=4.0)", "isort (>=4.2.2)", "mock (>=1.3.0)", "pydocstyle (>=1.0.0)", "pytest-cov (>=1.8.0)", "pytest-pep8 (>=1.0.6)", "pytest (>=2.8.0)", "tox (>=3.7.0)", "numpy (>=1.11.0)"]
@@ -110,29 +115,26 @@ numpy = ["numpy (>=1.11.0)"]
 tests = ["check-manifest (>=0.25)", "coverage (>=4.0)", "isort (>=4.2.2)", "mock (>=1.3.0)", "pydocstyle (>=1.0.0)", "pytest-cov (>=1.8.0)", "pytest-pep8 (>=1.0.6)", "pytest (>=2.8.0)", "tox (>=3.7.0)"]
 
 [[package]]
-category = "dev"
-description = "the modular source code checker: pep8 pyflakes and co"
 name = "flake8"
+version = "3.8.4"
+description = "the modular source code checker: pep8 pyflakes and co"
+category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "3.8.4"
 
 [package.dependencies]
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 mccabe = ">=0.6.0,<0.7.0"
 pycodestyle = ">=2.6.0a1,<2.7.0"
 pyflakes = ">=2.2.0,<2.3.0"
 
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = "*"
-
 [[package]]
-category = "main"
-description = "A non-official client for Goodreads (https://goodreads.com)"
 name = "goodreads-api-client"
+version = "0.1.0.dev4"
+description = "A non-official client for Goodreads (https://goodreads.com)"
+category = "main"
 optional = false
 python-versions = "*"
-version = "0.1.0.dev4"
 
 [package.dependencies]
 rauth = "0.7.3"
@@ -140,26 +142,25 @@ requests = "2.18.3"
 xmltodict = "0.11.0"
 
 [package.extras]
-docs = ["Sphinx (1.6.3)", "sphinx-autodoc-annotation (1.0.post1)", "sphinx-rtd-theme (0.2.4)"]
-publish = ["twine (1.9.1)", "wheel (0.29.0)"]
-test = ["codeclimate-test-reporter", "coverage (<4.4)", "doc8 (0.8.0)", "flake8 (3.4.1)", "vcrpy (1.11.1)"]
+docs = ["Sphinx (==1.6.3)", "sphinx-autodoc-annotation (==1.0.post1)", "sphinx-rtd-theme (==0.2.4)"]
+publish = ["twine (==1.9.1)", "wheel (==0.29.0)"]
+test = ["codeclimate-test-reporter", "coverage (<4.4)", "doc8 (==0.8.0)", "flake8 (==3.4.1)", "vcrpy (==1.11.1)"]
 
 [[package]]
-category = "main"
-description = "Internationalized Domain Names in Applications (IDNA)"
 name = "idna"
+version = "2.5"
+description = "Internationalized Domain Names in Applications (IDNA)"
+category = "main"
 optional = false
 python-versions = "*"
-version = "2.5"
 
 [[package]]
-category = "dev"
-description = "Read metadata from Python packages"
-marker = "python_version < \"3.8\""
 name = "importlib-metadata"
+version = "2.0.0"
+description = "Read metadata from Python packages"
+category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-version = "2.0.0"
 
 [package.dependencies]
 zipp = ">=0.5"
@@ -169,55 +170,55 @@ docs = ["sphinx", "rst.linker"]
 testing = ["packaging", "pep517", "importlib-resources (>=1.3)"]
 
 [[package]]
-category = "dev"
-description = "A Python utility / library to sort Python imports."
 name = "isort"
+version = "5.6.4"
+description = "A Python utility / library to sort Python imports."
+category = "dev"
 optional = false
 python-versions = ">=3.6,<4.0"
-version = "5.6.4"
 
 [package.extras]
-colors = ["colorama (>=0.4.3,<0.5.0)"]
 pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
 requirements_deprecated_finder = ["pipreqs", "pip-api"]
+colors = ["colorama (>=0.4.3,<0.5.0)"]
 
 [[package]]
-category = "dev"
-description = "A fast and thorough lazy object proxy."
 name = "lazy-object-proxy"
+version = "1.4.3"
+description = "A fast and thorough lazy object proxy."
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.4.3"
 
 [[package]]
-category = "main"
-description = "A lightweight library for converting complex datatypes to and from native Python datatypes."
 name = "marshmallow"
+version = "3.9.1"
+description = "A lightweight library for converting complex datatypes to and from native Python datatypes."
+category = "main"
 optional = false
 python-versions = ">=3.5"
-version = "3.9.1"
 
 [package.extras]
-dev = ["pytest", "pytz", "simplejson", "mypy (0.790)", "flake8 (3.8.4)", "flake8-bugbear (20.1.4)", "pre-commit (>=2.4,<3.0)", "tox"]
-docs = ["sphinx (3.3.0)", "sphinx-issues (1.2.0)", "alabaster (0.7.12)", "sphinx-version-warning (1.1.2)", "autodocsumm (0.2.1)"]
-lint = ["mypy (0.790)", "flake8 (3.8.4)", "flake8-bugbear (20.1.4)", "pre-commit (>=2.4,<3.0)"]
+dev = ["pytest", "pytz", "simplejson", "mypy (==0.790)", "flake8 (==3.8.4)", "flake8-bugbear (==20.1.4)", "pre-commit (>=2.4,<3.0)", "tox"]
+docs = ["sphinx (==3.3.0)", "sphinx-issues (==1.2.0)", "alabaster (==0.7.12)", "sphinx-version-warning (==1.1.2)", "autodocsumm (==0.2.1)"]
+lint = ["mypy (==0.790)", "flake8 (==3.8.4)", "flake8-bugbear (==20.1.4)", "pre-commit (>=2.4,<3.0)"]
 tests = ["pytest", "pytz", "simplejson"]
 
 [[package]]
-category = "dev"
-description = "McCabe checker, plugin for flake8"
 name = "mccabe"
+version = "0.6.1"
+description = "McCabe checker, plugin for flake8"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "0.6.1"
 
 [[package]]
-category = "main"
-description = "Unofficial Python API client for Notion.so"
 name = "notion"
+version = "0.0.25"
+description = "Unofficial Python API client for Notion.so"
+category = "main"
 optional = false
 python-versions = ">=3.5"
-version = "0.0.25"
 
 [package.dependencies]
 bs4 = "*"
@@ -229,43 +230,43 @@ requests = "*"
 tzlocal = "*"
 
 [[package]]
-category = "dev"
-description = "Python style guide checker"
 name = "pycodestyle"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "2.6.0"
-
-[[package]]
+description = "Python style guide checker"
 category = "dev"
-description = "passive checker of Python programs"
-name = "pyflakes"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.2.0"
 
 [[package]]
+name = "pyflakes"
+version = "2.2.0"
+description = "passive checker of Python programs"
 category = "dev"
-description = "python code static checker"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
 name = "pylint"
+version = "2.6.0"
+description = "python code static checker"
+category = "dev"
 optional = false
 python-versions = ">=3.5.*"
-version = "2.6.0"
 
 [package.dependencies]
 astroid = ">=2.4.0,<=2.5"
-colorama = "*"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
 isort = ">=4.2.5,<6"
 mccabe = ">=0.6,<0.7"
 toml = ">=0.7.1"
 
 [[package]]
-category = "main"
-description = "A Python Slugify application that handles Unicode"
 name = "python-slugify"
+version = "4.0.1"
+description = "A Python Slugify application that handles Unicode"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "4.0.1"
 
 [package.dependencies]
 text-unidecode = ">=1.3"
@@ -274,31 +275,31 @@ text-unidecode = ">=1.3"
 unidecode = ["Unidecode (>=1.1.1)"]
 
 [[package]]
-category = "main"
-description = "World timezone definitions, modern and historical"
 name = "pytz"
+version = "2020.4"
+description = "World timezone definitions, modern and historical"
+category = "main"
 optional = false
 python-versions = "*"
-version = "2020.4"
 
 [[package]]
-category = "main"
-description = "A Python library for OAuth 1.0/a, 2.0, and Ofly."
 name = "rauth"
+version = "0.7.3"
+description = "A Python library for OAuth 1.0/a, 2.0, and Ofly."
+category = "main"
 optional = false
 python-versions = "*"
-version = "0.7.3"
 
 [package.dependencies]
 requests = ">=1.2.3"
 
 [[package]]
-category = "main"
-description = "Python HTTP for Humans."
 name = "requests"
+version = "2.18.3"
+description = "Python HTTP for Humans."
+category = "main"
 optional = false
 python-versions = "*"
-version = "2.18.3"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
@@ -308,106 +309,103 @@ urllib3 = ">=1.21.1,<1.23"
 
 [package.extras]
 security = ["cryptography (>=1.3.4)", "idna (>=2.0.0)", "pyOpenSSL (>=0.14)"]
-socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
+socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
 
 [[package]]
-category = "dev"
-description = "Python 2 and 3 compatibility utilities"
 name = "six"
+version = "1.15.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "1.15.0"
 
 [[package]]
-category = "main"
-description = "A modern CSS selector implementation for Beautiful Soup."
-marker = "python_version >= \"3.0\""
 name = "soupsieve"
+version = "2.0.1"
+description = "A modern CSS selector implementation for Beautiful Soup."
+category = "main"
 optional = false
 python-versions = ">=3.5"
-version = "2.0.1"
 
 [[package]]
-category = "main"
-description = "The most basic Text::Unidecode port"
 name = "text-unidecode"
+version = "1.3"
+description = "The most basic Text::Unidecode port"
+category = "main"
 optional = false
 python-versions = "*"
-version = "1.3"
 
 [[package]]
-category = "dev"
-description = "Python Library for Tom's Obvious, Minimal Language"
 name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+category = "dev"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "0.10.2"
 
 [[package]]
-category = "dev"
-description = "a fork of Python 2 and 3 ast modules with type comment support"
-marker = "implementation_name == \"cpython\" and python_version < \"3.8\""
 name = "typed-ast"
+version = "1.4.1"
+description = "a fork of Python 2 and 3 ast modules with type comment support"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "1.4.1"
 
 [[package]]
-category = "main"
-description = "tzinfo object for the local timezone"
 name = "tzlocal"
+version = "2.1"
+description = "tzinfo object for the local timezone"
+category = "main"
 optional = false
 python-versions = "*"
-version = "2.1"
 
 [package.dependencies]
 pytz = "*"
 
 [[package]]
-category = "main"
-description = "HTTP library with thread-safe connection pooling, file post, and more."
 name = "urllib3"
+version = "1.22"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
 optional = false
 python-versions = "*"
-version = "1.22"
 
 [package.extras]
 secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
-socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
-category = "dev"
-description = "Module for decorators, wrappers and monkey patching."
 name = "wrapt"
-optional = false
-python-versions = "*"
 version = "1.12.1"
-
-[[package]]
-category = "main"
-description = "Makes working with XML feel like you are working with JSON"
-name = "xmltodict"
+description = "Module for decorators, wrappers and monkey patching."
+category = "dev"
 optional = false
 python-versions = "*"
-version = "0.11.0"
 
 [[package]]
-category = "dev"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-marker = "python_version < \"3.8\""
+name = "xmltodict"
+version = "0.11.0"
+description = "Makes working with XML feel like you are working with JSON"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "zipp"
+version = "3.4.0"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
-version = "3.4.0"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-content-hash = "23f99041c59afd91e9bdbed159c3f5175c33c9555f74cf28b5f815e6f4290d71"
-lock-version = "1.0"
+lock-version = "1.1"
 python-versions = "3.7.7"
+content-hash = "24aaf28cd8f69256ffaa25030810b26a0c78b15428837b573bc1c4ded0f947f7"
 
 [metadata.files]
 astroid = [
@@ -441,6 +439,10 @@ click = [
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+]
+colorlog = [
+    {file = "colorlog-4.6.2-py2.py3-none-any.whl", hash = "sha256:edd5ada5de03e880e42b2526f8be5570fd9b692f8eb7cf6b1fdcac3e3fb23976"},
+    {file = "colorlog-4.6.2.tar.gz", hash = "sha256:54e5f153419c22afc283c130c4201db19a3dbd83221a0f4657d5ee66234a2ea4"},
 ]
 commonmark = [
     {file = "commonmark-0.9.1-py2.py3-none-any.whl", hash = "sha256:da2f38c92590f83de410ba1a3cbceafbc74fee9def35f9251ba9a971d6d66fd9"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -128,11 +128,29 @@ version = "*"
 
 [[package]]
 category = "main"
+description = "A non-official client for Goodreads (https://goodreads.com)"
+name = "goodreads-api-client"
+optional = false
+python-versions = "*"
+version = "0.1.0.dev4"
+
+[package.dependencies]
+rauth = "0.7.3"
+requests = "2.18.3"
+xmltodict = "0.11.0"
+
+[package.extras]
+docs = ["Sphinx (1.6.3)", "sphinx-autodoc-annotation (1.0.post1)", "sphinx-rtd-theme (0.2.4)"]
+publish = ["twine (1.9.1)", "wheel (0.29.0)"]
+test = ["codeclimate-test-reporter", "coverage (<4.4)", "doc8 (0.8.0)", "flake8 (3.4.1)", "vcrpy (1.11.1)"]
+
+[[package]]
+category = "main"
 description = "Internationalized Domain Names in Applications (IDNA)"
 name = "idna"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.10"
+python-versions = "*"
+version = "2.5"
 
 [[package]]
 category = "dev"
@@ -265,20 +283,31 @@ version = "2020.4"
 
 [[package]]
 category = "main"
+description = "A Python library for OAuth 1.0/a, 2.0, and Ofly."
+name = "rauth"
+optional = false
+python-versions = "*"
+version = "0.7.3"
+
+[package.dependencies]
+requests = ">=1.2.3"
+
+[[package]]
+category = "main"
 description = "Python HTTP for Humans."
 name = "requests"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "2.25.0"
+python-versions = "*"
+version = "2.18.3"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
-chardet = ">=3.0.2,<4"
-idna = ">=2.5,<3"
-urllib3 = ">=1.21.1,<1.27"
+chardet = ">=3.0.2,<3.1.0"
+idna = ">=2.5,<2.6"
+urllib3 = ">=1.21.1,<1.23"
 
 [package.extras]
-security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
+security = ["cryptography (>=1.3.4)", "idna (>=2.0.0)", "pyOpenSSL (>=0.14)"]
 socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
 
 [[package]]
@@ -339,11 +368,10 @@ category = "main"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 name = "urllib3"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "1.26.2"
+python-versions = "*"
+version = "1.22"
 
 [package.extras]
-brotli = ["brotlipy (>=0.6.0)"]
 secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
 socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
 
@@ -354,6 +382,14 @@ name = "wrapt"
 optional = false
 python-versions = "*"
 version = "1.12.1"
+
+[[package]]
+category = "main"
+description = "Makes working with XML feel like you are working with JSON"
+name = "xmltodict"
+optional = false
+python-versions = "*"
+version = "0.11.0"
 
 [[package]]
 category = "dev"
@@ -369,9 +405,9 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-content-hash = "5f5f16a866c6fe7001e2cdcd125b0f33eb9df3b57299278cea9d013df51266e1"
+content-hash = "23f99041c59afd91e9bdbed159c3f5175c33c9555f74cf28b5f815e6f4290d71"
 lock-version = "1.0"
-python-versions = "^3.7"
+python-versions = "3.7.7"
 
 [metadata.files]
 astroid = [
@@ -418,9 +454,13 @@ flake8 = [
     {file = "flake8-3.8.4-py2.py3-none-any.whl", hash = "sha256:749dbbd6bfd0cf1318af27bf97a14e28e5ff548ef8e5b1566ccfb25a11e7c839"},
     {file = "flake8-3.8.4.tar.gz", hash = "sha256:aadae8761ec651813c24be05c6f7b4680857ef6afaae4651a4eccaef97ce6c3b"},
 ]
+goodreads-api-client = [
+    {file = "goodreads_api_client-0.1.0.dev4-py2.py3-none-any.whl", hash = "sha256:cb36e585cb2778a45dc4fa5f17d143d0bd80f5328d5c14511e914b2cb99c01c9"},
+    {file = "goodreads_api_client-0.1.0.dev4.tar.gz", hash = "sha256:a113e85179a08918d98b3152251c810f65a11114824193fad909b38622a40c6b"},
+]
 idna = [
-    {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
-    {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
+    {file = "idna-2.5-py2.py3-none-any.whl", hash = "sha256:cc19709fd6d0cbfed39ea875d29ba6d4e22c0cebc510a76d6302a28385e8bb70"},
+    {file = "idna-2.5.tar.gz", hash = "sha256:3cb5ce08046c4e3a560fc02f138d0ac63e00f8ce5901a56b32ec8b7994082aab"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-2.0.0-py2.py3-none-any.whl", hash = "sha256:cefa1a2f919b866c5beb7c9f7b0ebb4061f30a8a9bf16d609b000e2dfaceb9c3"},
@@ -484,9 +524,13 @@ pytz = [
     {file = "pytz-2020.4-py2.py3-none-any.whl", hash = "sha256:5c55e189b682d420be27c6995ba6edce0c0a77dd67bfbe2ae6607134d5851ffd"},
     {file = "pytz-2020.4.tar.gz", hash = "sha256:3e6b7dd2d1e0a59084bcee14a17af60c5c562cdc16d828e8eba2e683d3a7e268"},
 ]
+rauth = [
+    {file = "rauth-0.7.3-py2-none-any.whl", hash = "sha256:b18590fbd77bc3d871936bbdb851377d1b0c08e337b219c303f8fc2b5a42ef2d"},
+    {file = "rauth-0.7.3.tar.gz", hash = "sha256:524cdbc1c28560eacfc9a9d40c59525eb8d00fdf07fbad86107ea24411477b0a"},
+]
 requests = [
-    {file = "requests-2.25.0-py2.py3-none-any.whl", hash = "sha256:e786fa28d8c9154e6a4de5d46a1d921b8749f8b74e28bde23768e5e16eece998"},
-    {file = "requests-2.25.0.tar.gz", hash = "sha256:7f1a0b932f4a60a1a65caa4263921bb7d9ee911957e0ae4a23a6dd08185ad5f8"},
+    {file = "requests-2.18.3-py2.py3-none-any.whl", hash = "sha256:b62be4ec5999c24d10c98d248a136e7db20ca6616a2b65060cd9399417331e8a"},
+    {file = "requests-2.18.3.tar.gz", hash = "sha256:fb68a7baef4965c12d9cd67c0f5a46e6e28be3d8c7b6910c758fbcc99880b518"},
 ]
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
@@ -532,11 +576,15 @@ tzlocal = [
     {file = "tzlocal-2.1.tar.gz", hash = "sha256:643c97c5294aedc737780a49d9df30889321cbe1204eac2c2ec6134035a92e44"},
 ]
 urllib3 = [
-    {file = "urllib3-1.26.2-py2.py3-none-any.whl", hash = "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"},
-    {file = "urllib3-1.26.2.tar.gz", hash = "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08"},
+    {file = "urllib3-1.22-py2.py3-none-any.whl", hash = "sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b"},
+    {file = "urllib3-1.22.tar.gz", hash = "sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"},
 ]
 wrapt = [
     {file = "wrapt-1.12.1.tar.gz", hash = "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"},
+]
+xmltodict = [
+    {file = "xmltodict-0.11.0-py2.py3-none-any.whl", hash = "sha256:add07d92089ff611badec526912747cf87afd4f9447af6661aca074eeaf32615"},
+    {file = "xmltodict-0.11.0.tar.gz", hash = "sha256:8f8d7d40aa28d83f4109a7e8aa86e67a4df202d9538be40c0cb1d70da527b0df"},
 ]
 zipp = [
     {file = "zipp-3.4.0-py3-none-any.whl", hash = "sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -404,8 +404,8 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 
 [metadata]
 lock-version = "1.1"
-python-versions = "3.7.7"
-content-hash = "9cf63cad845c1cb334da3616c03f0bf3df14a8394ace6a3f977db5acdd8e8dd6"
+python-versions = "^3.7"
+content-hash = "049c999e96e283669387f6cb584e394abf5077782e6ddd7ff59f5d1669d3577d"
 
 [metadata.files]
 astroid = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -339,7 +339,7 @@ python-versions = "*"
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -405,7 +405,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "3.7.7"
-content-hash = "24aaf28cd8f69256ffaa25030810b26a0c78b15428837b573bc1c4ded0f947f7"
+content-hash = "9cf63cad845c1cb334da3616c03f0bf3df14a8394ace6a3f977db5acdd8e8dd6"
 
 [metadata.files]
 astroid = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ notion_scripts = "notion_scripts:main"
 scripts = "notion_scripts:main"
 
 [tool.poetry.dependencies]
-python = "3.7.7"
+python = "^3.7"
 notion = "^0.0.25"
 click = "^7.1.2"
 marshmallow = "^3.9.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,11 @@ license = "MIT"
 notion_scripts = "notion_scripts:main"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "3.7.7"
 notion = "^0.0.25"
 click = "^7.1.2"
 marshmallow = "^3.9.1"
+goodreads_api_client = "^0.1.0-alpha.4"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ license = "MIT"
 
 [tool.poetry.scripts]
 notion_scripts = "notion_scripts:main"
+scripts = "notion_scripts:main"
 
 [tool.poetry.dependencies]
 python = "3.7.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ click = "^7.1.2"
 marshmallow = "^3.9.1"
 goodreads_api_client = "^0.1.0-alpha.4"
 colorlog = "^4.6.2"
+toml = "^0.10.2"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ notion = "^0.0.25"
 click = "^7.1.2"
 marshmallow = "^3.9.1"
 goodreads_api_client = "^0.1.0-alpha.4"
+colorlog = "^4.6.2"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.6.0"


### PR DESCRIPTION
Added a command that will update a notion database with information from the goodreads API. I use it for my booklist to get things like the average rating and number of pages.

Unfortunately I couldn't find a way to add new options to select/multi-select options (I use them for author/publisher) which is a bummer but this is nice nonetheless.


```bash
Usage: scripts booklist [OPTIONS]

  Updates the given page/database with information from the goodreads API by
  matching books based on title. You can configure the mapping of column
  names to API results in the config.

Options:
  -p, --page TEXT  Notion URL to page/database to be updated
  --help           Show this message and exit.
```

<img width="1110" alt="image" src="https://user-images.githubusercontent.com/1175876/99876488-446f6680-2bf7-11eb-83c4-5fc17d3b045e.png">
